### PR TITLE
chore(build): add umd output

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
+  "umd": "lib/index.umd.js",
   "types": "lib/index.d.ts",
   "files": [
     "lib"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,12 @@ export default {
       file: pkg.module,
       sourcemap: true,
     },
+    {
+      format: "umd",
+      file: pkg.umd,
+      name: pkg.name,
+      sourcemap: true,
+    },
   ],
   external: Object.keys(pkg.dependencies || {}),
 };


### PR DESCRIPTION
how about add the `umd` build output?

so that easy to try in browser by

```html
<script type="text/javascript" src="lib/index.umd.js"></script>
```