### PR TITLE
Expose getEAWOfCodePoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,32 @@ assert(getEAW("ℵ") === "N");
 assert(getEAW("ℵAあＡｱ∀", 2) === "W");
 ```
 
+### `getEAWOfCodePoint()`
+
+Similar to `getEAW()`, but takes the code point instead of the string of a character.
+
+```javascript
+import { getEAWOfCodePoint } from .codePointAt(0)"meaw";
+ *
+// Narrow
+assert(getEAWOfCodePoint("A".codePointAt(0)) === "Na");
+// Wide
+assert(getEAWOfCodePoint("あ".codePointAt(0)) === "W");
+assert(getEAWOfCodePoint("安".codePointAt(0)) === "W");
+assert(getEAWOfCodePoint("🍣".codePointAt(0)) === "W");
+// Fullwidth
+assert(getEAWOfCodePoint("Ａ".codePointAt(0)) === "F");
+// Halfwidth
+assert(getEAWOfCodePoint("ｱ".codePointAt(0)) === "H");
+// Ambiguous
+assert(getEAWOfCodePoint("∀".codePointAt(0)) === "A");
+assert(getEAWOfCodePoint("→".codePointAt(0)) === "A");
+assert(getEAWOfCodePoint("Ω".codePointAt(0)) === "A");
+assert(getEAWOfCodePoint("Я".codePointAt(0)) === "A");
+// Neutral
+assert(getEAWOfCodePoint("ℵ".codePointAt(0)) === "N");
+```
+
 ### `computeWidth()`
 
 **Deprecated.** To calculate the visual width of a string, it is recommended to split the string into graphemes (using [`Intl.Segmenter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) or libraries like [graphemer](https://github.com/flmnt/graphemer)) and then calculate the widths of them.

--- a/README.md
+++ b/README.md
@@ -48,11 +48,10 @@ assert(getEAW("ℵAあＡｱ∀", 2) === "W");
 
 ### `getEAWOfCodePoint()`
 
-Similar to `getEAW()`, but takes the code point instead of the string of a character.
+Similar to `getEAW()`, but takes a code point (number) instead of a string.
 
 ```javascript
 import { getEAWOfCodePoint } from "meaw";
- *
 // Narrow
 assert(getEAWOfCodePoint("A".codePointAt(0)) === "Na");
 // Wide

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Similar to `getEAW()`, but takes a code point (number) instead of a string.
 
 ```javascript
 import { getEAWOfCodePoint } from "meaw";
+
 // Narrow
 assert(getEAWOfCodePoint("A".codePointAt(0)) === "Na");
 // Wide

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ assert(getEAW("ℵAあＡｱ∀", 2) === "W");
 Similar to `getEAW()`, but takes the code point instead of the string of a character.
 
 ```javascript
-import { getEAWOfCodePoint } from .codePointAt(0)"meaw";
+import { getEAWOfCodePoint } from "meaw";
  *
 // Narrow
 assert(getEAWOfCodePoint("A".codePointAt(0)) === "Na");

--- a/src/get-eaw.spec.ts
+++ b/src/get-eaw.spec.ts
@@ -34,22 +34,11 @@ describe("getEAW", () => {
       ["ℵAあＡｱ∀", "N"],
     ])("should return the EAW property of the first character / %s", (str, expected) => {
       expect(getEAW(str)).toBe(expected);
-      expect(getEAWOfCodePoint(str.codePointAt(0))).toBe(expected);
     });
 
     it("should return undefined if the string is empty", () => {
       expect(getEAW("")).toBe(undefined);
     });
-
-    it.each([
-      [[-1],
-      [0x110000],
-      [NaN],
-      [1.5],
-    ])("should return undefined for non-codepoint numbers"(cp) => {
-        expect(getEAWOfCodePoint(cp)).toBe(undefined);
-      }
-    ])
   });
 
   describe("with position specified", () => {
@@ -75,4 +64,47 @@ describe("getEAW", () => {
       expect(getEAW(str, pos)).toBe(undefined);
     });
   });
+});
+
+describe("getEAWOfCodePoint", () => {
+  it.each([
+    // # single characters
+    // ## Neutral
+    ["\x00", "N"],
+    ["ℵ", "N"],
+    // ## Narrow
+    ["1", "Na"],
+    ["A", "Na"],
+    ["a", "Na"],
+    [".", "Na"],
+    // ## Wide
+    ["あ", "W"],
+    ["ア", "W"],
+    ["安", "W"],
+    ["。", "W"],
+    ["🍣", "W"],
+    // ## Fullwidth
+    ["１", "F"],
+    ["Ａ", "F"],
+    ["ａ", "F"],
+    // ## Halfwidth
+    ["ｱ", "H"],
+    // ## Ambiguous
+    ["∀", "A"],
+    ["→", "A"],
+    ["Ω", "A"],
+    ["Я", "A"],
+    // # string
+    ["ℵAあＡｱ∀", "N"],
+  ])("should return the EAW property of the character / %s", (str, expected) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- character exists so never be undefined
+    expect(getEAWOfCodePoint(str.codePointAt(0)!)).toBe(expected);
+  });
+
+  it.each([[-1], [0x110000], [NaN], [1.5]])(
+    "should return undefined for non-codepoint numbers",
+    (cp) => {
+      expect(getEAWOfCodePoint(cp)).toBe(undefined);
+    },
+  );
 });

--- a/src/get-eaw.spec.ts
+++ b/src/get-eaw.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getEAW } from "./get-eaw";
+import { getEAW, getEAWOfCodePoint } from "./get-eaw";
 
 describe("getEAW", () => {
   describe("without position specified", () => {
@@ -34,11 +34,22 @@ describe("getEAW", () => {
       ["ℵAあＡｱ∀", "N"],
     ])("should return the EAW property of the first character / %s", (str, expected) => {
       expect(getEAW(str)).toBe(expected);
+      expect(getEAWOfCodePoint(str.codePointAt(0))).toBe(expected);
     });
 
     it("should return undefined if the string is empty", () => {
       expect(getEAW("")).toBe(undefined);
     });
+
+    it.each([
+      [[-1],
+      [0x110000],
+      [NaN],
+      [1.5],
+    ])("should return undefined for non-codepoint numbers"(cp) => {
+        expect(getEAWOfCodePoint(cp)).toBe(undefined);
+      }
+    ])
   });
 
   describe("with position specified", () => {

--- a/src/get-eaw.spec.ts
+++ b/src/get-eaw.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getEAW, getEAWOfCodePoint } from "./get-eaw";
+import { getEAW, getEAWOfCodePoint } from "./";
 
 describe("getEAW", () => {
   describe("without position specified", () => {

--- a/src/get-eaw.spec.ts
+++ b/src/get-eaw.spec.ts
@@ -72,6 +72,7 @@ describe("getEAWOfCodePoint", () => {
     // ## Neutral
     ["\x00", "N"],
     ["ℵ", "N"],
+    ["\u{10FFFF}", "N"],
     // ## Narrow
     ["1", "Na"],
     ["A", "Na"],

--- a/src/get-eaw.ts
+++ b/src/get-eaw.ts
@@ -49,7 +49,7 @@ function getEAWOfCodePointInternal(codePoint: number): EastAsianWidth {
  * assert(getEAWOfCodePoint("ℵ".codePointAt(0)) === "N");
  */
 export function getEAWOfCodePoint(codePoint: number): EastAsianWidth | undefined {
-  if (!Number.isInteger(codePoint) || codePoint < 0 || 0x10FFFF < codePoint) return undefined;
+  if (!Number.isInteger(codePoint) || codePoint < 0 || 0x10ffff < codePoint) return undefined;
   return getEAWOfCodePointInternal(codePoint);
 }
 

--- a/src/get-eaw.ts
+++ b/src/get-eaw.ts
@@ -28,7 +28,7 @@ function getEAWOfCodePointInternal(codePoint: number): EastAsianWidth {
  * @param codePoint Code point
  * @return The EAW property of the code point
  * @example
- * import { getEAWOfCodePoint } from .codePointAt(0)"meaw";
+ * import { getEAWOfCodePoint } from "meaw";
  *
  * // Narrow
  * assert(getEAWOfCodePoint("A".codePointAt(0)) === "Na");
@@ -49,7 +49,7 @@ function getEAWOfCodePointInternal(codePoint: number): EastAsianWidth {
  * assert(getEAWOfCodePoint("ℵ".codePointAt(0)) === "N");
  */
 export function getEAWOfCodePoint(codePoint: number): EastAsianWidth | undefined {
-  if (!Number.isInteger(codePoint) || codePoint <= 0 || 0x10FFFF <= codePoint) return undefined;
+  if (!Number.isInteger(codePoint) || codePoint < 0 || 0x10FFFF < codePoint) return undefined;
   return getEAWOfCodePointInternal(codePoint);
 }
 

--- a/src/get-eaw.ts
+++ b/src/get-eaw.ts
@@ -6,7 +6,7 @@ import { defs } from "./defs";
  * @param codePoint Code point
  * @return The EAW property of the code point
  */
-function getEAWOfCodePoint(codePoint: number): EastAsianWidth {
+function getEAWOfCodePointInternal(codePoint: number): EastAsianWidth {
   let min = 0;
   let max = defs.length - 1;
   while (min !== max) {
@@ -21,6 +21,36 @@ function getEAWOfCodePoint(codePoint: number): EastAsianWidth {
     }
   }
   return defs[min][2];
+}
+
+/**
+ * Gets the EAW property of a code point.
+ * @param codePoint Code point
+ * @return The EAW property of the code point
+ * @example
+ * import { getEAWOfCodePoint } from .codePointAt(0)"meaw";
+ *
+ * // Narrow
+ * assert(getEAWOfCodePoint("A".codePointAt(0)) === "Na");
+ * // Wide
+ * assert(getEAWOfCodePoint("あ".codePointAt(0)) === "W");
+ * assert(getEAWOfCodePoint("安".codePointAt(0)) === "W");
+ * assert(getEAWOfCodePoint("🍣".codePointAt(0)) === "W");
+ * // Fullwidth
+ * assert(getEAWOfCodePoint("Ａ".codePointAt(0)) === "F");
+ * // Halfwidth
+ * assert(getEAWOfCodePoint("ｱ".codePointAt(0)) === "H");
+ * // Ambiguous
+ * assert(getEAWOfCodePoint("∀".codePointAt(0)) === "A");
+ * assert(getEAWOfCodePoint("→".codePointAt(0)) === "A");
+ * assert(getEAWOfCodePoint("Ω".codePointAt(0)) === "A");
+ * assert(getEAWOfCodePoint("Я".codePointAt(0)) === "A");
+ * // Neutral
+ * assert(getEAWOfCodePoint("ℵ".codePointAt(0)) === "N");
+ */
+export function getEAWOfCodePoint(codePoint: number): EastAsianWidth | undefined {
+  if (!Number.isInteger(codePoint) || codePoint <= 0 || 0x10FFFF <= codePoint) return undefined;
+  return getEAWOfCodePointInternal(codePoint);
 }
 
 /**
@@ -57,5 +87,5 @@ export function getEAW(str: string, pos: number = 0): EastAsianWidth | undefined
   if (codePoint === undefined) {
     return undefined;
   }
-  return getEAWOfCodePoint(codePoint);
+  return getEAWOfCodePointInternal(codePoint);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { EastAsianWidth } from "./types";
 export { version as eawVersion } from "./defs";
-export { getEAW } from "./get-eaw";
+export { getEAW, getEAWOfCodePoint } from "./get-eaw";
 export { computeWidth } from "./compute-width";


### PR DESCRIPTION
I want to pass the code point of the character directly to `getEAW`, but the current `meaw` does not support this use case.

https://github.com/sindresorhus/get-east-asian-width supports it, but it is ESM-only.